### PR TITLE
Allow to replace ISPC_VERSION & ISPC_URL from cmdline

### DIFF
--- a/get_ispc.cmake
+++ b/get_ispc.cmake
@@ -1,7 +1,7 @@
 ## Copyright 2021 Intel Corporation
 ## SPDX-License-Identifier: Apache-2.0
 
-set(ISPC_VERSION 1.16.1)
+set(ISPC_VERSION 1.16.1 CACHE STRING "")
 
 set(SUBPROJECT_NAME ispc-v${ISPC_VERSION})
 
@@ -13,7 +13,7 @@ else()
   set(ISPC_SUFFIX "linux.tar.gz")
 endif()
 
-set(ISPC_URL "https://github.com/ispc/ispc/releases/download/v${ISPC_VERSION}/ispc-v${ISPC_VERSION}-${ISPC_SUFFIX}")
+set(ISPC_URL "https://github.com/ispc/ispc/releases/download/v${ISPC_VERSION}/ispc-v${ISPC_VERSION}-${ISPC_SUFFIX}" CACHE STRING "")
 
 ExternalProject_Add(ispc
   PREFIX ${SUBPROJECT_NAME}


### PR DESCRIPTION
To test new versions of ISPC with RenderKit superbuild we need to change these variables via cmdline (-D ISPC_VERSION= & -D ISPC_URL=).