### PR TITLE
ispc: use lib folder on Linux (after v1.25.0)

### DIFF
--- a/get_ispc.cmake
+++ b/get_ispc.cmake
@@ -1,4 +1,4 @@
-## Copyright 2021 Intel Corporation
+## Copyright 2021-2024 Intel Corporation
 ## SPDX-License-Identifier: Apache-2.0
 
 set(ISPC_VERSION 1.23.0 CACHE STRING "")
@@ -15,22 +15,8 @@ endif()
 
 set(ISPC_URL "https://github.com/ispc/ispc/releases/download/v${ISPC_VERSION}/ispc-v${ISPC_VERSION}-${ISPC_SUFFIX}" CACHE STRING "")
 
-if(WIN32)
-  set(_ISPC_SRC_LIB_NAME lib)
-  set(_ISPC_DST_LIB_NAME lib)
-elseif(APPLE)
-  set(_ISPC_SRC_LIB_NAME lib)
-  set(_ISPC_DST_LIB_NAME lib)
-else()
-  if(ISPC_VERSION MATCHES "dev")
-    set(_ISPC_SRC_LIB_NAME lib)
-    set(_ISPC_DST_LIB_NAME lib)
-  else()
-    set(_ISPC_SRC_LIB_NAME lib64)
-    set(_ISPC_DST_LIB_NAME lib64)
-  endif()
-  # set(FIND_LIBRARY_USE_LIB64_PATHS TRUE)
-endif()
+set(_ISPC_SRC_LIB_NAME lib)
+set(_ISPC_DST_LIB_NAME lib)
 
 ExternalProject_Add(ispc
   PREFIX ${SUBPROJECT_NAME}

--- a/get_ispc.cmake
+++ b/get_ispc.cmake
@@ -1,7 +1,7 @@
-## Copyright 2021-2024 Intel Corporation
+## Copyright 2021-2025 Intel Corporation
 ## SPDX-License-Identifier: Apache-2.0
 
-set(ISPC_VERSION 1.23.0 CACHE STRING "")
+set(ISPC_VERSION 1.25.3 CACHE STRING "")
 
 set(SUBPROJECT_NAME ispc-v${ISPC_VERSION})
 


### PR DESCRIPTION
After ISPC v1.25.0 `lib` folder is used across all platforms.